### PR TITLE
In memory High Availability/Cluster node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ target/
 *.db
 .DS_Store
 .classpath
+server/server-community/data/
+server/server-enterprise/data/

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,20 @@
             </dependency>
 
             <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-ha</artifactId>
+                <version>${neo4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.neo4j</groupId>
+                <artifactId>neo4j-management</artifactId>
+                <version>${neo4j.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-server</artifactId>
                 <version>9.2.4.v20141103</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -56,6 +56,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-ha</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j-management</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>

--- a/tests/src/main/java/com/graphaware/test/integration/HighAvailabilityDatabaseIntegrationTest.java
+++ b/tests/src/main/java/com/graphaware/test/integration/HighAvailabilityDatabaseIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.graphaware.test.integration;
+
+import org.neo4j.cluster.ClusterSettings;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.HighlyAvailableGraphDatabaseFactory;
+import org.neo4j.helpers.Settings;
+import org.neo4j.kernel.ha.HaSettings;
+import org.neo4j.server.configuration.Configurator;
+import org.neo4j.server.web.ServerInternalSettings;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static com.graphaware.common.util.DatabaseUtils.registerShutdownHook;
+import static org.neo4j.helpers.Settings.setting;
+import static org.neo4j.helpers.Settings.STRING;
+
+public class HighAvailabilityDatabaseIntegrationTest extends DatabaseIntegrationTest {
+
+    private static final String SERVER_ID = "1";
+    private static final String HA_SERVER = "localhost:6001";
+    private static final String SLAVE_ONLY = Settings.FALSE;
+    private static final String CLUSTER_SERVER = "localhost:5001";
+    private static final String INITIAL_HOSTS = "localhost:5001";
+    private static final String PATH = "target/graph-master";
+
+    @Override
+    protected GraphDatabaseService createDatabase() {
+        //This is deprecated, but I didn't find another way how to do it properly.
+        GraphDatabaseBuilder graphDatabaseBuilder = new HighlyAvailableGraphDatabaseFactory().newHighlyAvailableDatabaseBuilder(PATH);
+
+        if (propertiesFile() != null) {
+            graphDatabaseBuilder = graphDatabaseBuilder.loadPropertiesFromFile(propertiesFile());
+        } else {
+            setConfig(graphDatabaseBuilder);
+        }
+
+        GraphDatabaseService database = graphDatabaseBuilder.newGraphDatabase();
+        registerShutdownHook(database);
+        return database;
+    }
+
+    protected void setConfig(GraphDatabaseBuilder graphDatabaseBuilder) {
+        graphDatabaseBuilder.setConfig(ClusterSettings.server_id, SERVER_ID);
+        graphDatabaseBuilder.setConfig(HaSettings.ha_server, HA_SERVER);
+        graphDatabaseBuilder.setConfig(HaSettings.slave_only, SLAVE_ONLY);
+        graphDatabaseBuilder.setConfig(ClusterSettings.cluster_server, CLUSTER_SERVER);
+        graphDatabaseBuilder.setConfig(ClusterSettings.initial_hosts, INITIAL_HOSTS);
+    }
+}

--- a/tests/src/test/java/com/graphaware/test/integration/HighAvailabilityDatabaseIntegrationTestTest.java
+++ b/tests/src/test/java/com/graphaware/test/integration/HighAvailabilityDatabaseIntegrationTestTest.java
@@ -1,0 +1,27 @@
+package com.graphaware.test.integration;
+
+import org.junit.Test;
+import org.neo4j.management.ClusterMemberInfo;
+import org.neo4j.management.Neo4jManager;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+public class HighAvailabilityDatabaseIntegrationTestTest extends HighAvailabilityDatabaseIntegrationTest {
+
+    @Test
+    public void shouldStartHighAvailabilityDatabase() {
+        Neo4jManager manager = Neo4jManager.get();
+
+        org.neo4j.management.HighAvailability highAvailabilityBean = manager.getHighAvailabilityBean();
+
+        assertNotNull(highAvailabilityBean);
+
+        final ClusterMemberInfo[] instancesInCluster = highAvailabilityBean.getInstancesInCluster();
+
+        assertEquals(1, instancesInCluster.length);
+
+        assertEquals("1", instancesInCluster[0].getInstanceId());
+        assertEquals("master", instancesInCluster[0].getHaRole());
+    }
+}


### PR DESCRIPTION
It could be useful in some cases to have in-memory HA node. For instance when you need test JMX endpoints or extension, which rely on cluster.