### PR TITLE
reverted skipped test for RC1

### DIFF
--- a/tests/src/test/java/com/graphaware/test/integration/WrappingServerIntegrationTestTest.java
+++ b/tests/src/test/java/com/graphaware/test/integration/WrappingServerIntegrationTestTest.java
@@ -29,7 +29,6 @@ public class WrappingServerIntegrationTestTest extends WrappingServerIntegration
 
     @Test
     public void shouldLoadWebAdmin() {
-        //Skip test until RC2
-        //httpClient.get(baseNeoUrl() + "/webadmin", SC_OK);
+        httpClient.get(baseNeoUrl() + "/webadmin", SC_OK);
     }
 }

--- a/tx-api/src/test/java/com/graphaware/tx/event/improved/LazyTransactionDataSmokeTest.java
+++ b/tx-api/src/test/java/com/graphaware/tx/event/improved/LazyTransactionDataSmokeTest.java
@@ -172,7 +172,7 @@ public class LazyTransactionDataSmokeTest {
         verify("Deleted relationship (:Person {name: Michal})-[:FRIEND_OF {since: 2007}]->(:Person {name: Daniela})");
     }
 
-    //@Test
+    @Test
     public void multipleChangesShouldBeCorrectlyPickedUp() {
         execute("CREATE (:Person {name:'Michal'})-[:FRIEND_OF {since:2007}]->(:Person {name:'Daniela'})");
 


### PR DESCRIPTION
@bachmanm In RC1 we skipped a test because the webadmin endpoint was inadvertently removed in RC1. 

I de-commented the test and it is passing.