### PR TITLE
stopwatch into framework

### DIFF
--- a/common/src/main/java/com/graphaware/common/stopwatch/Event.java
+++ b/common/src/main/java/com/graphaware/common/stopwatch/Event.java
@@ -1,0 +1,41 @@
+package com.graphaware.common.stopwatch;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Event {
+
+    private Long start;
+
+    private List<Period> periods = new ArrayList<>();
+
+    private boolean isStopped = false;
+
+    public Event() {
+        start = System.currentTimeMillis();
+    }
+
+    public void stop() {
+        periods.add(new Period(getLastPeriodTime(), System.currentTimeMillis()));
+    }
+
+    public Long getStartTime() {
+        return start;
+    }
+
+    public Long duration() {
+        return getLastPeriodTime() - start;
+    }
+
+    public void addPeriod() {
+        periods.add(new Period(getLastPeriodTime(), System.currentTimeMillis()));
+    }
+
+    public List<Period> getPeriods() {
+        return periods;
+    }
+
+    private Long getLastPeriodTime() {
+        return periods.size() == 0 ? start : periods.get(periods.size()-1).endTime();
+    }
+}

--- a/common/src/main/java/com/graphaware/common/stopwatch/Period.java
+++ b/common/src/main/java/com/graphaware/common/stopwatch/Period.java
@@ -1,0 +1,31 @@
+package com.graphaware.common.stopwatch;
+
+public class Period {
+
+    private Long start;
+
+    private Long end;
+
+    public Period(Long start, Long end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public Long startTime() {
+        return start;
+    }
+
+    public Long endTime() {
+        return end;
+    }
+
+    public Long duration() {
+        return end - start;
+    }
+
+    @Override
+    public String toString() {
+        return this.duration() + " ms";
+    }
+
+}

--- a/common/src/main/java/com/graphaware/common/stopwatch/Stopwatch.java
+++ b/common/src/main/java/com/graphaware/common/stopwatch/Stopwatch.java
@@ -1,0 +1,43 @@
+package com.graphaware.common.stopwatch;
+
+import java.util.HashMap;
+
+public class Stopwatch {
+
+    private HashMap<String, Event> events = new HashMap<>();
+
+    public void start(String eventName) {
+        startEvent(eventName);
+    }
+
+    public Event stop(String eventName) {
+        return stopEvent(eventName);
+    }
+
+    public void lap(String eventName) {
+        ensureEventExists(eventName);
+        events.get(eventName).addPeriod();
+    }
+
+    private void startEvent(String eventName) {
+        if (events.containsKey(eventName)) {
+            throw new IllegalArgumentException("An event with name " + eventName + " was already started");
+        }
+
+        events.put(eventName, new Event());
+    }
+
+    private Event stopEvent(String eventName) {
+        ensureEventExists(eventName);
+        events.get(eventName).stop();
+
+        return events.get(eventName);
+    }
+
+    private void ensureEventExists(String eventName) {
+        if (!events.containsKey(eventName)) {
+            throw new IllegalArgumentException("No event with name " + eventName + " has been started");
+        }
+    }
+
+}

--- a/common/src/test/java/com/graphaware/common/stopwatch/EventTest.java
+++ b/common/src/test/java/com/graphaware/common/stopwatch/EventTest.java
@@ -1,0 +1,43 @@
+package com.graphaware.common.stopwatch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EventTest {
+
+    @Test
+    public void shouldStartOnCreate() {
+        Event event = new Event();
+        assertTrue(event.duration().equals(event.getStartTime()));
+    }
+
+    @Test
+    public void shouldAddPeriodOnStop() throws InterruptedException{
+        Event event = new Event();
+        sleep(100L);
+        event.stop();
+        assertTrue(event.duration() > 100);
+        assertEquals(1, event.getPeriods().size());
+    }
+
+    @Test
+    public void shouldHandleLaps() throws InterruptedException{
+        Event event = new Event();
+        sleep(100L);
+        event.addPeriod();
+        sleep(100L);
+        event.stop();
+
+        assertEquals(100, event.getPeriods().get(0).duration(), 10L);
+        assertEquals(100, event.getPeriods().get(1).duration(), 10L);
+        assertEquals(200, event.duration(), 20L);
+        assertEquals(2, event.getPeriods().size());
+    }
+
+    private void sleep(Long millis) throws InterruptedException{
+        Thread.sleep(millis);
+    }
+
+}

--- a/common/src/test/java/com/graphaware/common/stopwatch/PeriodTest.java
+++ b/common/src/test/java/com/graphaware/common/stopwatch/PeriodTest.java
@@ -1,0 +1,26 @@
+package com.graphaware.common.stopwatch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PeriodTest {
+
+    @Test
+    public void shouldReturnStartAndEndTime() {
+        Long t = System.currentTimeMillis();
+        Long t2 = System.currentTimeMillis();
+        Period period = new Period(t, t2);
+        assertEquals(t, period.startTime());
+        assertEquals(t2, period.endTime());
+    }
+
+    @Test
+    public void shouldReturnDuration() {
+        Long t = System.currentTimeMillis();
+        Long t2 = t + 1000;
+        Period period = new Period(t, t2);
+        assertEquals(1000, period.duration(), 0L);
+    }
+
+}

--- a/common/src/test/java/com/graphaware/common/stopwatch/StopwatchTest.java
+++ b/common/src/test/java/com/graphaware/common/stopwatch/StopwatchTest.java
@@ -1,0 +1,47 @@
+package com.graphaware.common.stopwatch;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class StopwatchTest {
+
+    @Test
+    public void shouldHandleEvents() {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start("e1");
+        stopwatch.start("e2");
+        Event e = stopwatch.stop("e1");
+        assertEquals(1, e.getPeriods().size());
+        assertEquals(e.getStartTime(), e.getPeriods().get(0).startTime());
+        Event e2 = stopwatch.stop("e2");
+        assertEquals(1, e2.getPeriods().size());
+    }
+
+    @Test
+    public void shouldHandleLaps() throws InterruptedException{
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start("e");
+        Thread.sleep(100);
+        stopwatch.lap("e");
+        Thread.sleep(100);
+        stopwatch.lap("e");
+        Event e = stopwatch.stop("e");
+
+        assertEquals(3, e.getPeriods().size());
+        assertEquals(200, e.duration(), 20L);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenStopButNotStarted() {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.stop("e");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowExceptionWhenTryingToStartAlreadyStartedEvent() {
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start("e");
+        stopwatch.start("e");
+    }
+}


### PR DESCRIPTION
@bachmanm please tell me what you think.

Good replacement for manually using `System.currentTimeMillis()` : 

Example : 

``` java

Stopwatch stopwatch = new Stopwatch();

stopwatch.start("engine1");
// find candidates()
Event e1 = stopwatch.stop("engine1");
System.out.println(e1.duration());

stopwatch.start("complexWorker");
stopwatch.lap("complexWorker");
stopwatch.lap("complexWorker");
Event e2 = stopwatch.stop("complexWorker");
System.out.println(e2.duration());
System.out.println(e2.getPeriods.get(0).duration());
```
