### PR TITLE
Decrease coupling to Spring / Cypher.

### DIFF
--- a/api/src/main/java/com/graphaware/api/SerializableNode.java
+++ b/api/src/main/java/com/graphaware/api/SerializableNode.java
@@ -20,11 +20,8 @@ import com.graphaware.api.transform.NodeIdTransformer;
 import com.graphaware.common.representation.NodeRepresentation;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
-import org.springframework.util.Assert;
 
 import java.util.Map;
-
-import static org.springframework.util.Assert.*;
 
 /**
  * Serializable {@link NodeRepresentation} with custom node ID. It is recommended not to expose Neo4j internal IDs (graphId)

--- a/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeNodes.java
+++ b/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeNodes.java
@@ -18,10 +18,9 @@ package com.graphaware.common.policy.fluent;
 
 import com.graphaware.common.description.property.DetachedPropertiesDescription;
 import com.graphaware.common.policy.NodeInclusionPolicy;
-import org.neo4j.graphdb.Label;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.parboiled.common.StringUtils;
 
 /**
  * Abstract base class for {@link NodeInclusionPolicy} implementations with fluent interface,

--- a/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeProperties.java
+++ b/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeProperties.java
@@ -17,8 +17,8 @@
 package com.graphaware.common.policy.fluent;
 
 import com.graphaware.common.policy.PropertyInclusionPolicy;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.PropertyContainer;
-import org.parboiled.common.StringUtils;
 
 /**
  * Abstract base class for {@link com.graphaware.common.policy.PropertyInclusionPolicy} implementations with fluent interface,

--- a/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeRelationships.java
+++ b/common/src/main/java/com/graphaware/common/policy/fluent/BaseIncludeRelationships.java
@@ -19,8 +19,8 @@ package com.graphaware.common.policy.fluent;
 import com.graphaware.common.description.property.DetachedPropertiesDescription;
 import com.graphaware.common.policy.RelationshipInclusionPolicy;
 import com.graphaware.common.util.DirectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.*;
-import org.parboiled.common.StringUtils;
 
 import java.util.Arrays;
 import java.util.LinkedList;

--- a/common/src/main/java/com/graphaware/common/util/PropertyContainerUtils.java
+++ b/common/src/main/java/com/graphaware/common/util/PropertyContainerUtils.java
@@ -18,17 +18,16 @@ package com.graphaware.common.util;
 
 import com.graphaware.common.policy.ObjectInclusionPolicy;
 import com.graphaware.common.policy.all.IncludeAll;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
-import org.parboiled.common.StringUtils;
 
 import java.util.*;
 
 import static com.graphaware.common.util.ArrayUtils.isPrimitiveOrStringArray;
 import static com.graphaware.common.util.ArrayUtils.primitiveOrStringArrayToString;
-import static org.springframework.util.Assert.notNull;
 
 /**
  * Utility methods for dealing with {@link org.neo4j.graphdb.PropertyContainer}s.
@@ -60,7 +59,7 @@ public final class PropertyContainerUtils {
      * @throws IllegalStateException in case the propertyContainer is not a {@link org.neo4j.graphdb.Node} or a {@link org.neo4j.graphdb.Relationship}.
      */
     public static long id(PropertyContainer propertyContainer) {
-        notNull(propertyContainer);
+        Objects.requireNonNull(propertyContainer);
 
         if (Node.class.isAssignableFrom(propertyContainer.getClass())) {
             return ((Node) propertyContainer).getId();

--- a/tx-executor/src/main/java/com/graphaware/tx/executor/input/TransactionalInput.java
+++ b/tx-executor/src/main/java/com/graphaware/tx/executor/input/TransactionalInput.java
@@ -23,9 +23,9 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.PrefetchingIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.Assert;
 
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * An {@link Iterable}, items of which are retrieved from the database in batches. Intended to be used as
@@ -51,9 +51,11 @@ public class TransactionalInput<T> extends PrefetchingIterator<T> implements Ite
      * @param callback  which actually retrieves an iterable from the database.
      */
     public TransactionalInput(GraphDatabaseService database, int batchSize, TransactionCallback<Iterable<T>> callback) {
-        Assert.notNull(database);
-        Assert.isTrue(batchSize > 0);
-        Assert.notNull(callback);
+        Objects.requireNonNull(database);
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize argument must be greater than zero");
+        }
+        Objects.requireNonNull(callback);
 
         this.database = database;
         this.callback = callback;


### PR DESCRIPTION
Scenario:
 * Neo4j embedded, without Cypher
 * Selectively using graphaware common, tx-api & timetree
 * No Spring

This commit removes imports of StringUtils from parboiled (transitive
dep from Cypher), I'm assuming these are accidential. I have replaced
them with calls to commons-lang's StringUtils.

Then there are some usages of Spring's Assert helper class, mostly the
notNull method. I replaced these calls with Objects.requireNonNull (a
not widely known method introduced in Java 7).

These changes allow very selectively depeding on just three graphaware
modules (excluding all transitive dependencies) without having to bring
in Cypher or Spring.

--
This PR is against the 3.0 branch. If you prefer a PR against master to forward-merge from let me know. 