### PR TITLE
shorthand inclusion policies

### DIFF
--- a/runtime/src/main/java/com/graphaware/runtime/config/function/StringToNodeInclusionPolicy.java
+++ b/runtime/src/main/java/com/graphaware/runtime/config/function/StringToNodeInclusionPolicy.java
@@ -18,6 +18,7 @@ package com.graphaware.runtime.config.function;
 
 import com.graphaware.common.policy.NodeInclusionPolicy;
 import com.graphaware.common.policy.composite.CompositeNodeInclusionPolicy;
+import com.graphaware.common.policy.none.IncludeNoNodes;
 import com.graphaware.common.policy.spel.SpelNodeInclusionPolicy;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
 
@@ -30,6 +31,15 @@ public final class StringToNodeInclusionPolicy extends StringToInclusionPolicy<N
 
     public static StringToNodeInclusionPolicy getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public NodeInclusionPolicy apply(String expression) {
+        switch (expression) {
+            case "true": return IncludeAllBusinessNodes.getInstance();
+            case "false": return IncludeNoNodes.getInstance();
+            default: return super.apply(expression);
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/graphaware/runtime/config/function/StringToNodePropertyInclusionPolicy.java
+++ b/runtime/src/main/java/com/graphaware/runtime/config/function/StringToNodePropertyInclusionPolicy.java
@@ -17,7 +17,9 @@
 package com.graphaware.runtime.config.function;
 
 import com.graphaware.common.policy.NodePropertyInclusionPolicy;
+import com.graphaware.common.policy.all.IncludeAllNodeProperties;
 import com.graphaware.common.policy.composite.CompositeNodePropertyInclusionPolicy;
+import com.graphaware.common.policy.none.IncludeNoNodeProperties;
 import com.graphaware.common.policy.spel.SpelNodePropertyInclusionPolicy;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodeProperties;
 
@@ -30,6 +32,15 @@ public final class StringToNodePropertyInclusionPolicy extends StringToInclusion
 
     public static StringToNodePropertyInclusionPolicy getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public NodePropertyInclusionPolicy apply(String expression) {
+        switch (expression) {
+            case "true": return IncludeAllNodeProperties.getInstance();
+            case "false": return IncludeNoNodeProperties.getInstance();
+            default: return super.apply(expression);
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/graphaware/runtime/config/function/StringToRelationshipInclusionPolicy.java
+++ b/runtime/src/main/java/com/graphaware/runtime/config/function/StringToRelationshipInclusionPolicy.java
@@ -18,6 +18,7 @@ package com.graphaware.runtime.config.function;
 
 import com.graphaware.common.policy.RelationshipInclusionPolicy;
 import com.graphaware.common.policy.composite.CompositeRelationshipInclusionPolicy;
+import com.graphaware.common.policy.none.IncludeNoRelationships;
 import com.graphaware.common.policy.spel.SpelRelationshipInclusionPolicy;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationships;
 
@@ -30,6 +31,15 @@ public final class StringToRelationshipInclusionPolicy extends StringToInclusion
 
     public static StringToRelationshipInclusionPolicy getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public RelationshipInclusionPolicy apply(String expression) {
+        switch (expression) {
+            case "true": return IncludeAllBusinessRelationships.getInstance();
+            case "false": return IncludeNoRelationships.getInstance();
+            default: return super.apply(expression);
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/graphaware/runtime/config/function/StringToRelationshipPropertyInclusionPolicy.java
+++ b/runtime/src/main/java/com/graphaware/runtime/config/function/StringToRelationshipPropertyInclusionPolicy.java
@@ -17,7 +17,9 @@
 package com.graphaware.runtime.config.function;
 
 import com.graphaware.common.policy.RelationshipPropertyInclusionPolicy;
+import com.graphaware.common.policy.all.IncludeAllRelationshipProperties;
 import com.graphaware.common.policy.composite.CompositeRelationshipPropertyInclusionPolicy;
+import com.graphaware.common.policy.none.IncludeNoRelationshipProperties;
 import com.graphaware.common.policy.spel.SpelRelationshipPropertyInclusionPolicy;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessRelationshipProperties;
 
@@ -32,6 +34,14 @@ public final class StringToRelationshipPropertyInclusionPolicy extends StringToI
         return INSTANCE;
     }
 
+    @Override
+    public RelationshipPropertyInclusionPolicy apply(String expression) {
+        switch (expression) {
+            case "true": return IncludeAllRelationshipProperties.getInstance();
+            case "false": return IncludeNoRelationshipProperties.getInstance();
+            default: return super.apply(expression);
+        }
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Fixes #51 by adding "true" and "false" shorthand inclusion policies.
- NodeInclusionPolicy:
 - true = IncludeAllBusinessNodes
 - false = IncludeNoNodes
- NodePropertiesInclusionPolicy:
 - true = IncludeAllNodeProperties
 - false = IncludeNoNodeProperties
- RelationshipInclusionPolicy:
 - true = IncludeAllBusinessRelationships
 - false = IncludeNoRelationships
- RelationshipPropertiesInclusionPolicy:
 - true = IncludeAllRelationshipProperties
 - false = - IncludeNoRelationshipProperties