### PR TITLE
On simple inclusion policies, do not scan whole DB

### DIFF
--- a/common/src/main/java/com/graphaware/common/policy/spel/SpelInclusionPolicy.java
+++ b/common/src/main/java/com/graphaware/common/policy/spel/SpelInclusionPolicy.java
@@ -17,6 +17,8 @@
 package com.graphaware.common.policy.spel;
 
 import org.springframework.expression.Expression;
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
@@ -26,11 +28,15 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
 public abstract class SpelInclusionPolicy {
 
     protected transient final Expression exp;
+    protected transient final SpelNode expressionNode;
+
     private final String expression;
 
     protected SpelInclusionPolicy(String expression) {
+        SpelExpressionParser parser = new SpelExpressionParser();
         this.expression = expression;
-        this.exp = new SpelExpressionParser().parseExpression(expression);
+        this.expressionNode = parser.parseRaw(expression).getAST();
+        this.exp = parser.parseExpression(expression);
     }
 
     /**

--- a/common/src/main/java/com/graphaware/common/policy/spel/SpelInclusionPolicy.java
+++ b/common/src/main/java/com/graphaware/common/policy/spel/SpelInclusionPolicy.java
@@ -18,7 +18,6 @@ package com.graphaware.common.policy.spel;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.SpelNode;
-import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**

--- a/common/src/main/java/com/graphaware/common/policy/spel/SpelNodeInclusionPolicy.java
+++ b/common/src/main/java/com/graphaware/common/policy/spel/SpelNodeInclusionPolicy.java
@@ -20,14 +20,7 @@ import com.graphaware.common.policy.NodeInclusionPolicy;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.FilteringIterable;
-import org.springframework.expression.spel.SpelNode;
-import org.springframework.expression.spel.ast.OpOr;
-import org.springframework.expression.spel.standard.SpelExpressionParser;
-
-import java.util.Iterator;
-import java.util.Objects;
 
 /**
  * {@link NodeInclusionPolicy} based on a SPEL expression. The expression can use methods defined in {@link NodeExpressions}.

--- a/common/src/test/java/com/graphaware/common/policy/spel/SpelInclusionPolicyTest.java
+++ b/common/src/test/java/com/graphaware/common/policy/spel/SpelInclusionPolicyTest.java
@@ -21,14 +21,13 @@ import org.junit.Before;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static com.graphaware.common.util.DatabaseUtils.registerShutdownHook;
 import static com.graphaware.common.util.IterableUtils.getSingle;
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.graphdb.RelationshipType.*;
+import static org.neo4j.graphdb.RelationshipType.withName;
 
 /**
  * Abstract base class for {@link com.graphaware.common.policy.spel.SpelInclusionPolicy} implementation unit tests.

--- a/common/src/test/java/com/graphaware/common/policy/spel/SpelNodeInclusionPolicyTest.java
+++ b/common/src/test/java/com/graphaware/common/policy/spel/SpelNodeInclusionPolicyTest.java
@@ -28,6 +28,9 @@ import static org.junit.Assert.*;
  */
 public class SpelNodeInclusionPolicyTest extends SpelInclusionPolicyTest {
 
+    private NodeInclusionPolicy simplePolicy1;
+    private NodeInclusionPolicy simplePolicy2;
+
     private NodeInclusionPolicy policy1;
     private NodeInclusionPolicy policy2;
     private NodeInclusionPolicy policy3;
@@ -37,6 +40,9 @@ public class SpelNodeInclusionPolicyTest extends SpelInclusionPolicyTest {
     @Override
     public void setUp() {
         super.setUp();
+
+        simplePolicy1 = new SpelNodeInclusionPolicy("hasLabel('Employee')");
+        simplePolicy2 = new SpelNodeInclusionPolicy("!hasLabel('Employee')");
 
         policy1 = new SpelNodeInclusionPolicy("hasLabel('Employee') || hasProperty('form') || getProperty('age', 0) > 20");
         policy2 = new SpelNodeInclusionPolicy("getDegree('OUTGOING') > 1");
@@ -48,6 +54,16 @@ public class SpelNodeInclusionPolicyTest extends SpelInclusionPolicyTest {
     @Test
     public void shouldIncludeCorrectNodes() {
         try (Transaction tx = database.beginTx()) {
+            assertTrue(simplePolicy1.include(michal()));
+            assertFalse(simplePolicy1.include(graphaware()));
+            assertFalse(simplePolicy1.include(vojta()));
+            assertFalse(simplePolicy1.include(london()));
+
+            assertFalse(simplePolicy2.include(michal()));
+            assertTrue(simplePolicy2.include(graphaware()));
+            assertTrue(simplePolicy2.include(vojta()));
+            assertTrue(simplePolicy2.include(london()));
+
             assertTrue(policy1.include(michal()));
             assertTrue(policy1.include(graphaware()));
             assertTrue(policy1.include(vojta()));
@@ -80,8 +96,23 @@ public class SpelNodeInclusionPolicyTest extends SpelInclusionPolicyTest {
     @Test
     public void shouldCorrectlyGetAllNodes() {
         try (Transaction tx = database.beginTx()) {
+            assertEquals(1, Iterables.count(simplePolicy1.getAll(database)));
+            assertEquals(michal(), simplePolicy1.getAll(database).iterator().next());
+
+            assertEquals(3, Iterables.count(simplePolicy2.getAll(database)));
+
+            assertEquals(3, Iterables.count(policy1.getAll(database)));
+
+            assertEquals(2, Iterables.count(policy2.getAll(database)));
+
             assertEquals(1, Iterables.count(policy3.getAll(database)));
             assertEquals(graphaware(), policy3.getAll(database).iterator().next());
+
+            assertEquals(1, Iterables.count(policy4.getAll(database)));
+            assertEquals(graphaware(), policy4.getAll(database).iterator().next());
+
+            assertEquals(0, Iterables.count(policy5.getAll(database)));
+
             tx.success();
         }
     }


### PR DESCRIPTION
as per "when people use a single label (and maybe multiple lables separated by or (||)), we don't use a Spel policy but a dedicated programmatic policy, so that we can find all nodes/relationships efficiently without needing to evaluate the Spel expression for all nodes in the db."