### PR TITLE
Add 'none' and 'all' as keywords that load up inclusion policies

### DIFF
--- a/runtime/src/main/java/com/graphaware/runtime/config/function/StringToInclusionPolicy.java
+++ b/runtime/src/main/java/com/graphaware/runtime/config/function/StringToInclusionPolicy.java
@@ -21,6 +21,9 @@ import com.graphaware.common.policy.all.IncludeAllNodeProperties;
 import com.graphaware.common.policy.none.IncludeNoNodeProperties;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -33,16 +36,19 @@ public abstract class StringToInclusionPolicy<T extends InclusionPolicy> impleme
 
     private static final Pattern CLASS_NAME_REGEX = Pattern.compile("([\\p{L}_$][\\p{L}\\p{N}_$]*\\.)*[\\p{L}_$][\\p{L}\\p{N}_$]*");
 
+    private static final Set<String> ALL_BUSINESS_NODES_POLICY = new HashSet<>(Arrays.asList("true", "all"));
+    private static final Set<String> EXCLUDE_ALL_NODES_POLICY = new HashSet<>(Arrays.asList("false", "none"));
+
     /**
      * {@inheritDoc}
      */
     @Override
     public T apply(String s) {
-        if ("true".equals(s)) {
+        if (ALL_BUSINESS_NODES_POLICY.contains(s)) {
             return all();
         }
 
-        if ("false".equals(s)) {
+        if (EXCLUDE_ALL_NODES_POLICY.contains(s)) {
             return none();
         }
 

--- a/runtime/src/test/java/com/graphaware/runtime/config/function/StringToNodeInclusionPolicyTest.java
+++ b/runtime/src/test/java/com/graphaware/runtime/config/function/StringToNodeInclusionPolicyTest.java
@@ -17,6 +17,7 @@
 package com.graphaware.runtime.config.function;
 
 import com.graphaware.common.policy.NodeInclusionPolicy;
+import com.graphaware.common.policy.none.IncludeNoNodes;
 import com.graphaware.common.policy.spel.SpelNodeInclusionPolicy;
 import com.graphaware.runtime.policy.all.IncludeAllBusinessNodes;
 import org.junit.Test;
@@ -29,6 +30,33 @@ import static org.junit.Assert.assertNotNull;
  * Unit test for {@link StringToNodeInclusionPolicy}.
  */
 public class StringToNodeInclusionPolicyTest {
+
+
+    @Test
+    public void shouldConstructPolicyFromAllNodesKeywords() {
+        NodeInclusionPolicy policy1 = StringToNodeInclusionPolicy.getInstance().apply("all");
+
+        assertNotNull(policy1);
+        assertEquals(IncludeAllBusinessNodes.getInstance(), policy1);
+
+        NodeInclusionPolicy policy2 = StringToNodeInclusionPolicy.getInstance().apply("true");
+
+        assertNotNull(policy2);
+        assertEquals(IncludeAllBusinessNodes.getInstance(), policy2);
+    }
+
+    @Test
+    public void shouldConstructPolicyFromExcludeAllNodesKeywords() {
+        NodeInclusionPolicy policy1 = StringToNodeInclusionPolicy.getInstance().apply("false");
+
+        assertNotNull(policy1);
+        assertEquals(IncludeNoNodes.getInstance(), policy1);
+
+        NodeInclusionPolicy policy2 = StringToNodeInclusionPolicy.getInstance().apply("none");
+
+        assertNotNull(policy2);
+        assertEquals(IncludeNoNodes.getInstance(), policy2);
+    }
 
     @Test
     public void shouldConstructPolicyFromClassName() {


### PR DESCRIPTION
Note that when this is merged, there's a separate task to update documentation in other libraries that use this config parser where relevant.