### PR TITLE
Make use of addActiveProfile() rather than setActiveProfiles() so as …

### DIFF
--- a/server/src/main/java/com/graphaware/server/foundation/context/GraphAwareWebContextCreator.java
+++ b/server/src/main/java/com/graphaware/server/foundation/context/GraphAwareWebContextCreator.java
@@ -47,13 +47,13 @@ public class GraphAwareWebContextCreator extends BaseWebContextCreator {
 
     private void configureStatsCollector(AnnotationConfigWebApplicationContext context, Config config) {
         if (Boolean.valueOf(config.getParams().getOrDefault(GA_API_STATS_DISABLE_SETTING_LEGACY, "false"))) {
-            context.getEnvironment().setActiveProfiles("stats-null");
+            context.getEnvironment().addActiveProfile("stats-null");
         }
         else if (Boolean.valueOf(config.getParams().getOrDefault(GA_API_STATS_DISABLE_SETTING, "false"))) {
-            context.getEnvironment().setActiveProfiles("stats-null");
+            context.getEnvironment().addActiveProfile("stats-null");
         }
         else {
-            context.getEnvironment().setActiveProfiles("stats-google");
+            context.getEnvironment().addActiveProfile("stats-google");
         }
     }
 


### PR DESCRIPTION
It may be an improvement to make use of 
```context.getEnvironment().addActiveProfile()``` rather than ```context.getEnvironment().setActiveProfiles()``` so as to not overwrite any other potentially existing profiles.

http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/ConfigurableEnvironment.html#addActiveProfile-java.lang.String-

vs

http://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/ConfigurableEnvironment.html#setActiveProfiles-java.lang.String...-