### PR TITLE
Add support to topology changes

### DIFF
--- a/runtime/src/main/java/com/graphaware/runtime/DatabaseRuntime.java
+++ b/runtime/src/main/java/com/graphaware/runtime/DatabaseRuntime.java
@@ -17,17 +17,20 @@
 package com.graphaware.runtime;
 
 import com.graphaware.runtime.config.RuntimeConfiguration;
+import com.graphaware.runtime.listener.TopologyChangeEventListener;
+import com.graphaware.runtime.listener.TopologyListenerAdapter;
 import com.graphaware.runtime.manager.TxDrivenModuleManager;
 import com.graphaware.runtime.module.RuntimeModule;
 import com.graphaware.runtime.module.TxDrivenModule;
 import com.graphaware.writer.neo4j.Neo4jWriter;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 
 /**
  * {@link com.graphaware.runtime.TxDrivenRuntime} backed by a {@link GraphDatabaseService}.
  * <p/>
- * Supports only {@link com.graphaware.runtime.module.TxDrivenModule} {@link com.graphaware.runtime.module.RuntimeModule}s as it might be backed by a {@link org.neo4j.unsafe.batchinsert.BatchGraphDatabaseImpl}.
+ * Supports only {@link com.graphaware.runtime.module.TxDrivenModule} {@link com.graphaware.runtime.module.RuntimeModule}s.
  * <p/>
  * To use this {@link com.graphaware.runtime.GraphAwareRuntime}, please construct it using {@link com.graphaware.runtime.GraphAwareRuntimeFactory}.
  */
@@ -36,6 +39,7 @@ public class DatabaseRuntime extends TxDrivenRuntime<TxDrivenModule> {
     private final GraphDatabaseService database;
     private final TxDrivenModuleManager<TxDrivenModule> txDrivenModuleManager;
     private final Neo4jWriter writer;
+    private TopologyListenerAdapter topologyListenerAdapter;
 
     /**
      * Construct a new runtime. Protected, please use {@link com.graphaware.runtime.GraphAwareRuntimeFactory}.
@@ -43,7 +47,7 @@ public class DatabaseRuntime extends TxDrivenRuntime<TxDrivenModule> {
      * @param configuration         config.
      * @param database              on which the runtime operates.
      * @param txDrivenModuleManager manager for transaction-driven modules.
-     * @param writer        to use when writing to the database.
+     * @param writer                to use when writing to the database.
      */
     protected DatabaseRuntime(RuntimeConfiguration configuration, GraphDatabaseService database, TxDrivenModuleManager<TxDrivenModule> txDrivenModuleManager, Neo4jWriter writer) {
         super(configuration);
@@ -52,7 +56,12 @@ public class DatabaseRuntime extends TxDrivenRuntime<TxDrivenModule> {
         this.writer = writer;
         database.registerTransactionEventHandler(this);
         database.registerKernelEventHandler(this);
+
+        // Register to topology change events
+        // In Community Edition this raises a ClassNotFoundException
+        this.topologyListenerAdapter = new TopologyListenerAdapter((GraphDatabaseAPI) database);
     }
+
 
     /**
      * {@inheritDoc}
@@ -70,6 +79,11 @@ public class DatabaseRuntime extends TxDrivenRuntime<TxDrivenModule> {
         if (module instanceof TxDrivenModule) {
             txDrivenModuleManager.registerModule((TxDrivenModule) module);
         }
+
+        // If the module is a TopologyChangeEventListener then we should register this module as a listener
+        if (this.topologyListenerAdapter != null && module instanceof TopologyChangeEventListener) {
+            this.topologyListenerAdapter.registerListener((TopologyChangeEventListener) module);
+        }
     }
 
     /**
@@ -79,6 +93,12 @@ public class DatabaseRuntime extends TxDrivenRuntime<TxDrivenModule> {
     protected final void afterShutdown() {
         super.afterShutdown();
         afterShutdown(database);
+
+        // Remove all listeners and un-register adapter
+        if (this.topologyListenerAdapter != null) {
+            this.topologyListenerAdapter.unregister();
+            this.topologyListenerAdapter = null;
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/graphaware/runtime/listener/TopologyChangeEvent.java
+++ b/runtime/src/main/java/com/graphaware/runtime/listener/TopologyChangeEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2013-2017 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.runtime.listener;
+
+import com.graphaware.common.policy.role.InstanceRole;
+
+/**
+ * Abstraction of a topology change event.
+ * This event will be fired both with HA cluster and Causal cluster
+ */
+public interface TopologyChangeEvent {
+
+    /**
+     * The id that is related to the instance leaving, joining the cluster or elected
+     *
+     * @return instance id related to the instance leaving, joining the cluster or elected
+     */
+    String getInstanceId();
+
+    /**
+     * The id that is related to the instance that is receiving the event
+     *
+     * @return instance id for this instance
+     */
+    String getOwnInstanceId();
+
+    /**
+     * The role that is related to the instance that is receiving the event
+     *
+     * @return instance role for this instance {@link InstanceRole}
+     */
+    InstanceRole getOwnInstanceRole();
+
+    /**
+     * @return type of the event that is occurred {@link EventType}
+     */
+    EventType getEventType();
+
+    /**
+     * Type of events that are normalized respect to the different events that can occurs when running an HA or a Causal cluster
+     */
+    enum EventType {
+        // When an instance leave the cluster
+        CLUSTER_LEAVE,
+        // When an instance join the cluster
+        CLUSTER_JOIN,
+        // When an election occurs
+        ELECTION
+    }
+}

--- a/runtime/src/main/java/com/graphaware/runtime/listener/TopologyChangeEventListener.java
+++ b/runtime/src/main/java/com/graphaware/runtime/listener/TopologyChangeEventListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2013-2017 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.runtime.listener;
+
+/**
+ * Topology change listener that fires when the cluster topology changes
+ * All modules that want to be notified for topology changes must implement this interface
+ *
+ */
+public interface TopologyChangeEventListener {
+
+    /**
+     * This event will be fired when a change in topology occurs
+     * @param topologyChangeEvent
+     */
+    void onTopologyChange(TopologyChangeEvent topologyChangeEvent);
+}

--- a/runtime/src/main/java/com/graphaware/runtime/listener/TopologyListenerAdapter.java
+++ b/runtime/src/main/java/com/graphaware/runtime/listener/TopologyListenerAdapter.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2013-2017 GraphAware
+ *
+ * This file is part of the GraphAware Framework.
+ *
+ * GraphAware Framework is free software: you can redistribute it and/or modify it under the terms of
+ * the GNU General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details. You should have received a copy of
+ * the GNU General Public License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+package com.graphaware.runtime.listener;
+
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.common.policy.role.InstanceRole;
+import com.graphaware.runtime.config.util.InstanceRoleUtils;
+import org.neo4j.causalclustering.discovery.CoreTopology;
+import org.neo4j.causalclustering.discovery.CoreTopologyService;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.cluster.client.ClusterClient;
+import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
+import org.neo4j.cluster.protocol.cluster.ClusterListener;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.kernel.ha.cluster.member.ClusterMember;
+import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
+import org.neo4j.kernel.impl.factory.OperationalMode;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This class is an adapter listening to topology changes both for HA clusters and Causal ones
+ */
+public final class TopologyListenerAdapter implements ClusterListener, CoreTopologyService.Listener {
+
+    protected final Log LOG = LoggerFactory.getLogger(TopologyListenerAdapter.class);
+
+    List<TopologyChangeEventListener> topologyChangeEventListeners = new ArrayList<>();
+
+    private DependencyResolver dependencyResolver;
+
+    private OperationalMode operationalMode;
+
+    public TopologyListenerAdapter(final GraphDatabaseAPI api) {
+        operationalMode = new InstanceRoleUtils(api).getOperationalMode();
+        dependencyResolver = api.getDependencyResolver();
+
+        // HA cluster
+        if (operationalMode.equals(OperationalMode.ha)) {
+            dependencyResolver.resolveDependency(ClusterClient.class).addClusterListener(this);
+        }
+        // Core
+        if (operationalMode.equals(OperationalMode.core)) {
+            dependencyResolver.resolveDependency(CoreTopologyService.class).addCoreTopologyListener(this);
+        }
+    }
+
+    /**
+     * Register a listener for topology change events
+     *
+     * @param topologyChangeEventListener
+     */
+    public void registerListener(TopologyChangeEventListener topologyChangeEventListener) {
+        this.topologyChangeEventListeners.add(topologyChangeEventListener);
+    }
+
+    /**
+     * Remove a listener
+     *
+     * @param topologyChangeEventListener
+     */
+    public void removeListener(TopologyChangeEventListener topologyChangeEventListener) {
+        this.topologyChangeEventListeners.remove(topologyChangeEventListener);
+    }
+
+    /**
+     * Un-register this adapter
+     */
+    public void unregister() {
+        this.topologyChangeEventListeners.clear();
+
+        if (operationalMode.equals(OperationalMode.ha)) {
+            dependencyResolver.resolveDependency(ClusterClient.class).removeClusterListener(this);
+        }
+
+        // There is no removeListener for Causal Cluster
+    }
+
+    /**
+     * For each (registered) listener fire the event
+     *
+     * @param topologyChangeEvent
+     */
+    private void fireEvent(TopologyChangeEvent topologyChangeEvent) {
+        this.topologyChangeEventListeners.forEach(listener -> listener.onTopologyChange(topologyChangeEvent));
+    }
+
+    /**
+     * Creates a {@link TopologyChangeEvent} from a {@link CoreTopology} object
+     * This is used only in case of Causal Cluster mode
+     *
+     * @param coreTopology
+     * @return
+     */
+    private TopologyChangeEvent topologyChangeEventFromCausalCluster(CoreTopology coreTopology) {
+        // TODO: convert coreTopology into TopologyChangeEvent
+        return null;
+    }
+
+    /**
+     * Creates a {@link TopologyChangeEvent} from a {@link InstanceId} object
+     * This is used only in case of HA mode
+     *
+     * @param instanceId
+     * @return
+     */
+    private TopologyChangeEvent topologyChangeEventFromHighAvailability(final InstanceId instanceId, final TopologyChangeEvent.EventType eventType) {
+        // This member, "this" instance receiving the event
+        final ClusterMember thisMember = getHAClusterMembers().getCurrentMember();
+
+        return new TopologyChangeEventImpl(instanceId.toString(),
+                thisMember.getInstanceId().toString(),
+                haInstanceRoleFromString(thisMember.getHARole()),
+                eventType);
+    }
+
+    /**
+     * @param instanceId
+     * @return
+     */
+    private TopologyChangeEvent topologyChangeEventFromHighAvailabilityElection(final InstanceId instanceId) {
+        final ClusterMember thisMember = getHAClusterMembers().getCurrentMember();
+
+        // TODO: give explanation to this logic
+        InstanceRole role = InstanceRole.SLAVE;
+        // FIXME
+        if (instanceId.equals(thisMember.getInstanceId())) {
+            role = InstanceRole.MASTER;
+        }
+
+        return new TopologyChangeEventImpl(instanceId.toString(),
+                thisMember.getInstanceId().toString(),
+                role,
+                TopologyChangeEvent.EventType.ELECTION);
+    }
+
+    private ClusterMembers getHAClusterMembers() {
+        return dependencyResolver.resolveDependency(ClusterMembers.class);
+    }
+
+    // TODO use InstanceRoleUtils instead of this method?
+    private InstanceRole haInstanceRoleFromString(String haInstanceRole) {
+        return haInstanceRole.equals("master") ? InstanceRole.MASTER : InstanceRole.SLAVE;
+    }
+
+    // ----- HIGH AVAILABILITY EVENTS -----
+
+    @Override
+    public void enteredCluster(ClusterConfiguration clusterConfiguration) {
+        // DO NOTHING
+    }
+
+    @Override
+    public void leftCluster() {
+        // DO NOTHING
+    }
+
+    @Override
+    public void joinedCluster(InstanceId instanceId, URI uri) {
+        fireEvent(topologyChangeEventFromHighAvailability(instanceId, TopologyChangeEvent.EventType.CLUSTER_JOIN));
+    }
+
+    @Override
+    public void leftCluster(InstanceId instanceId, URI uri) {
+        fireEvent(topologyChangeEventFromHighAvailability(instanceId, TopologyChangeEvent.EventType.CLUSTER_LEAVE));
+    }
+
+    @Override
+    public void elected(String s, InstanceId instanceId, URI uri) {
+        fireEvent(topologyChangeEventFromHighAvailabilityElection(instanceId));
+    }
+
+    @Override
+    public void unelected(String s, InstanceId instanceId, URI uri) {
+        // DO NOTHING
+    }
+
+    // ----- CAUSAL CLUSTER EVENT -----
+
+    @Override
+    public void onCoreTopologyChange(CoreTopology coreTopology) {
+        LOG.info(String.format("onCoreTopologyChange %s", coreTopology));
+        fireEvent(topologyChangeEventFromCausalCluster(coreTopology));
+    }
+
+    // ----- Inner implementation for a TopologyChangeEvent ---- ///
+
+    private class TopologyChangeEventImpl implements TopologyChangeEvent {
+
+        /**
+         * The instance id (joining or leaving the cluster so that generating the event)
+         */
+        private final String instanceId;
+
+        /**
+         * The instance id receiving the event
+         */
+        private final String ownInstanceId;
+
+        /**
+         * The event type
+         */
+        private final EventType eventType;
+
+        /**
+         * The instance role receiving the event
+         */
+        private final InstanceRole ownInstanceRole;
+
+        public TopologyChangeEventImpl(String instanceId, String ownInstanceId, InstanceRole ownInstanceRole, EventType eventType) {
+            this.instanceId = instanceId;
+            this.ownInstanceId = ownInstanceId;
+            this.ownInstanceRole = ownInstanceRole;
+            this.eventType = eventType;
+        }
+
+        @Override
+        public String getInstanceId() {
+            return instanceId;
+        }
+
+        @Override
+        public String getOwnInstanceId() {
+            return ownInstanceId;
+        }
+
+        @Override
+        public InstanceRole getOwnInstanceRole() {
+            return ownInstanceRole;
+        }
+
+        public EventType getEventType() {
+            return eventType;
+        }
+
+        @Override
+        public String toString() {
+            return Stream.of("[instanceId=", getInstanceId(),
+                    ",ownInstanceId=", getOwnInstanceId(),
+                    ",ownInstanceRole=", getOwnInstanceRole().toString(),
+                    ",eventType=", getEventType().toString() + "]")
+                    .collect(Collectors.joining());
+        }
+    }
+}

--- a/runtime/src/test/java/com/graphaware/runtime/TopologyAwareRuntimeTest.java
+++ b/runtime/src/test/java/com/graphaware/runtime/TopologyAwareRuntimeTest.java
@@ -1,0 +1,142 @@
+package com.graphaware.runtime;
+
+import com.graphaware.common.policy.role.InstanceRole;
+import com.graphaware.runtime.listener.TopologyChangeEvent;
+import com.graphaware.runtime.listener.TopologyChangeEventListener;
+import com.graphaware.runtime.module.RuntimeModule;
+import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesIntegrationTest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.ha.cluster.member.ClusterMembers;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class TopologyAwareRuntimeTest extends HighAvailabilityClusterDatabasesIntegrationTest {
+
+    private static ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    private static List<GraphDatabaseService> databases;
+
+    private static AtomicInteger clusterLeaveEvents = new AtomicInteger();
+
+    private static AtomicInteger clusterElectionEvents = new AtomicInteger();
+
+    private static AtomicInteger finalNumberOfMasters = new AtomicInteger();
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        executorService.submit(() -> {
+            try {
+                System.out.println("wait before shutting down all the instances");
+                Thread.sleep(5000);
+                List<Map<InstanceId, String>> members = databases.stream()
+                        .map(db -> ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(ClusterMembers.class).getCurrentMember())
+                        .map(currentMember -> {
+                            if (currentMember != null) {
+                                return Collections.singletonMap(currentMember.getInstanceId(), currentMember.getHARole());
+                            }
+                            return new HashMap<InstanceId, String>();
+                        })
+                        .collect(Collectors.toList());
+
+                System.out.println("shutting down all the instances: " + members);
+                databases.forEach(GraphDatabaseService::shutdown);
+
+            } catch (Exception e) {
+
+            }
+        }).get();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        databases = getDatabases();
+    }
+
+    @Override
+    public boolean shouldRegisterModules() {
+        return true;
+    }
+
+    @Override
+    public void registerModule(GraphDatabaseService db) throws Exception {
+        GraphAwareRuntime runtime = GraphAwareRuntimeFactory.createRuntime(db);
+        runtime.registerModule(new TopologyAwareModule());
+    }
+
+    @Test
+    public void testMasterShutdown() throws Exception {
+        Future<?> future = executorService.submit(() -> {
+
+            ClusterMembers clusterMembers = ((GraphDatabaseAPI) getMasterDatabase())
+                    .getDependencyResolver()
+                    .resolveDependency(ClusterMembers.class);
+            LOG.info(String.format("shutdown instance %s", clusterMembers.getCurrentMember()));
+            getMasterDatabase().shutdown();
+        });
+        future.get();
+
+        Thread.sleep(2000);
+
+        // We should have 2 "cluster leave" events: two for each remaining instance
+        assertEquals(2, clusterLeaveEvents.intValue());
+        // We should have 2 "cluster election" events: two for each remaining instance
+        assertEquals(2, clusterElectionEvents.intValue());
+
+        LOG.info("Cluster leave events: " + clusterLeaveEvents.intValue());
+        LOG.info("Cluster election events: " + clusterElectionEvents.intValue());
+
+        // Of course, we should have only one master at the end of the new election
+        assertEquals(1, finalNumberOfMasters.intValue());
+        LOG.info("Number of final master instances: " + finalNumberOfMasters.intValue());
+    }
+
+    class TopologyAwareModule implements RuntimeModule, TopologyChangeEventListener {
+
+        @Override
+        public String getId() {
+            return "TOPOLOGY_AWARE";
+        }
+
+        @Override
+        public void shutdown() {
+
+        }
+
+        public void onTopologyChange(TopologyChangeEvent topologyChangeEvent) {
+            LOG.info("onTopologyChange: " + topologyChangeEvent);
+            assertNotNull(topologyChangeEvent.getInstanceId());
+            assertNotNull(topologyChangeEvent.getOwnInstanceId());
+            assertNotNull(topologyChangeEvent.getOwnInstanceRole());
+
+            if (topologyChangeEvent.getEventType().equals(TopologyChangeEvent.EventType.CLUSTER_LEAVE)) {
+                clusterLeaveEvents.incrementAndGet();
+            }
+
+            if (topologyChangeEvent.getEventType().equals(TopologyChangeEvent.EventType.ELECTION)) {
+                clusterElectionEvents.incrementAndGet();
+            }
+
+            if (topologyChangeEvent.getOwnInstanceRole().equals(InstanceRole.MASTER)) {
+                finalNumberOfMasters.incrementAndGet();
+            }
+        }
+    }
+}

--- a/runtime/src/test/java/com/graphaware/runtime/listener/TopologyListenerAdapterTest.java
+++ b/runtime/src/test/java/com/graphaware/runtime/listener/TopologyListenerAdapterTest.java
@@ -1,0 +1,111 @@
+package com.graphaware.runtime.listener;
+
+import com.graphaware.common.log.LoggerFactory;
+import com.graphaware.common.policy.role.InstanceRole;
+import com.graphaware.test.integration.cluster.HighAvailabilityClusterDatabasesIntegrationTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.cluster.InstanceId;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+
+public class TopologyListenerAdapterTest extends HighAvailabilityClusterDatabasesIntegrationTest {
+
+    private static final InstanceId instanceId = new InstanceId(0);
+
+    protected final Log LOG = LoggerFactory.getLogger(TopologyListenerAdapterTest.class);
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    protected List<Class<?>> getTopology() {
+        // One master
+        return Arrays.asList(HighlyAvailableGraphDatabase.class);
+    }
+
+    @Test
+    public void testRegisterListener() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        adapter.registerListener((TopologyChangeEvent topologyChangeEvent) -> {
+        });
+
+        assertEquals(1, adapter.topologyChangeEventListeners.size());
+    }
+
+    @Test
+    public void testUnregisterListener() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        TopologyChangeEventListener listener = (TopologyChangeEvent topologyChangeEvent) -> {
+        };
+        adapter.registerListener(listener);
+
+        assertEquals(1, adapter.topologyChangeEventListeners.size());
+
+        adapter.removeListener(listener);
+        assertEquals(0, adapter.topologyChangeEventListeners.size());
+    }
+
+    @Test
+    public void testIfUnregisterShouldNotFireEvents() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        TopologyChangeEventListener listener = (TopologyChangeEvent topologyChangeEvent) -> {
+            LOG.info("This should never fail");
+            fail();
+        };
+
+        adapter.registerListener(listener);
+        assertEquals(1, adapter.topologyChangeEventListeners.size());
+
+        adapter.removeListener(listener);
+        assertEquals(0, adapter.topologyChangeEventListeners.size());
+
+        adapter.joinedCluster(instanceId, null);
+    }
+
+    @Test
+    public void testJoinClusterEvent() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        adapter.registerListener((TopologyChangeEvent topologyChangeEvent) -> {
+            assertEquals(instanceId.toString(), topologyChangeEvent.getInstanceId());
+            assertEquals(TopologyChangeEvent.EventType.CLUSTER_JOIN, topologyChangeEvent.getEventType());
+        });
+
+        // fire fake event
+        adapter.joinedCluster(instanceId, null);
+    }
+
+    @Test
+    public void testLeaveClusterEvent() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        adapter.registerListener((TopologyChangeEvent topologyChangeEvent) -> {
+            assertEquals(instanceId.toString(), topologyChangeEvent.getInstanceId());
+            assertEquals(TopologyChangeEvent.EventType.CLUSTER_LEAVE, topologyChangeEvent.getEventType());
+        });
+
+        // fire fake event
+        adapter.leftCluster(instanceId, null);
+    }
+
+    @Test
+    public void testElectionEvent() {
+        TopologyListenerAdapter adapter = new TopologyListenerAdapter((GraphDatabaseAPI) getMasterDatabase());
+        adapter.registerListener((TopologyChangeEvent topologyChangeEvent) -> {
+            assertEquals(instanceId.toString(), topologyChangeEvent.getInstanceId());
+            assertEquals(TopologyChangeEvent.EventType.ELECTION, topologyChangeEvent.getEventType());
+            assertEquals(InstanceRole.MASTER, topologyChangeEvent.getOwnInstanceRole());
+        });
+
+        // fire fake event
+        adapter.elected("elected", instanceId, null);
+    }
+}


### PR DESCRIPTION
It will be helpful if each module can listen to topology changes in order to change its behaviour.

A module must implement the TopologyChangeEventListener interface in order to listen to a TopologyChangeEvent.
When a change in topology occurs than it will be notified about this event receiving a TopologyChangeEvent.

This event will have the following fields:

- instanceId, the unique identifier that is related to the instance leaving, joining the cluster or that has been elected
- ownInstanceId, the unique identifier that is related to the instance that is receiving the event
- ownInstanceRole, the role that is related to the instance that is receiving the event
- eventType, the type of the event (JOIN, LEAVE OR ELECTION)

This event is an abstraction over the different events that can occur when using an HA cluster or a Causal one.