### PR TITLE
Hazelcast address resolution fix

### DIFF
--- a/tests/src/main/java/com/graphaware/test/integration/cluster/CausalClusterDatabasesintegrationTest.java
+++ b/tests/src/main/java/com/graphaware/test/integration/cluster/CausalClusterDatabasesintegrationTest.java
@@ -71,9 +71,9 @@ public abstract class CausalClusterDatabasesintegrationTest extends ClusterDatab
 		if (instanceClass.equals(CoreGraphDatabase.class)) {
 			params.put(CausalClusteringSettings.expected_core_cluster_size.name(), String.valueOf(coreClusterSize));
 
-			params.put(CausalClusteringSettings.discovery_listen_address.name(), "localhost:510" + i);
-			params.put(CausalClusteringSettings.transaction_listen_address.name(), "localhost:600" + i);
-			params.put(CausalClusteringSettings.raft_listen_address.name(), "localhost:700" + i);
+			params.put(CausalClusteringSettings.discovery_listen_address.name(), "127.0.0.1:510" + i);
+			params.put(CausalClusteringSettings.transaction_listen_address.name(), "127.0.0.1:600" + i);
+			params.put(CausalClusteringSettings.raft_listen_address.name(), "127.0.0.1:700" + i);
 		}
 
 		return params;


### PR DESCRIPTION
Using local hostname seems to throw exception depending on the environment (unit tests from IDE, maven tests, etc)
Hostnames are replaced with the local ip address.