### PR TITLE
Replace maven assembly plugin with maven shade plugin

### DIFF
--- a/build/graphaware-framework-server/pom.xml
+++ b/build/graphaware-framework-server/pom.xml
@@ -38,23 +38,30 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4.1</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.objectweb.asm</pattern>
+                            <shadedPattern>ga.relocation.org.objectweb.asm</shadedPattern>
+                            <includes>
+                                <include>org.objectweb.asm.**</include>
+                            </includes>
+                        </relocation>
+                    </relocations>
+                    <!-- This is module has packaging type pom, otherwise finalName could have been used -->
+                    <outputFile>${project.build.directory}/graphaware-server-all-${project.version}.jar</outputFile>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>single</goal>
+                            <goal>shade</goal>
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <finalName>graphaware-server-all-${project.version}</finalName>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
There are is asm dependency, which conflicts with apoc.
This relocates the package of the library within our plugin.
Can be used to relocate other dependencies.