### PR TITLE
Issue/83

### DIFF
--- a/graphaware-apoc-dependency-test/pom.xml
+++ b/graphaware-apoc-dependency-test/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+    No parent here so we don't inherit dependency management wich would cause maven-enforcer-plugin
+    not to work as we want.
+    -->
+
+    <groupId>com.graphaware.neo4j</groupId>
+    <artifactId>graphaware-apoc-dependency-test</artifactId>
+    <version>3.3.2.52-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>GraphAware Framework and APOC dependency conflict test</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>com.graphaware.neo4j</groupId>
+            <artifactId>server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.neo4j.procedure</groupId>
+            <artifactId>apoc</artifactId>
+            <version>3.3.0.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <modules>
         <module>parent-pom/framework</module>
         <module>parent-pom/module</module>
+        <module>graphaware-apoc-dependency-test</module>
     </modules>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.10</version>
+                <version>1.9</version>
             </dependency>
 
             <!-- Serialization -->
@@ -493,19 +493,19 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.6.5</version>
+                <version>2.9.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.6.5</version>
+                <version>2.9.0</version>
             </dependency>
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.6.5</version>
+                <version>2.9.0</version>
             </dependency>
 
             <!-- Spring -->


### PR DESCRIPTION
Was able to reproduce issue #83 both on enterprise and community under following:

```
$ ls -U plugins
graphaware-server-all-3.3.2.52-SNAPSHOT.jar  apoc-3.3.0.1-all.jar
```

Solved by synchronising dependencies with apoc.
Jackson 2.6.5 -> 2.9.0 should be fine (jackson follows semver)
commons-codec 1.10 -> 1.9 - not sure, all tests pass so hopefully fine. We could do PR to apoc if we really need 1.10.

Added dummy module to check these conflicts during build (happens in `verify` phase) - wasn't sure where to put it. Can be anywhere, just don't add a <parent> to it. We will need to update apoc dependency version when new apoc is released.