### PR TITLE
Fix of the classpath for Windows

### DIFF
--- a/server/src/test/java/com/graphaware/test/GraphAwareIntegrationTestTest.java
+++ b/server/src/test/java/com/graphaware/test/GraphAwareIntegrationTestTest.java
@@ -37,12 +37,12 @@ public class GraphAwareIntegrationTestTest extends GraphAwareIntegrationTest {
     @Test
     public void shouldRegisterProcedureOnClasspath() {
         Assert.assertEquals(
-                "+---------+\n" +
-                "| string  |\n" +
-                "+---------+\n" +
-                "| \"hello\" |\n" +
-                "+---------+\n" +
-                "1 row\n",
+                "+---------+" + System.lineSeparator() +
+                "| string  |" + System.lineSeparator() +
+                "+---------+" + System.lineSeparator() +
+                "| \"hello\" |" + System.lineSeparator() +
+                "+---------+" + System.lineSeparator() +
+                "1 row" + System.lineSeparator(),
                 getDatabase().execute("CALL ga.hello()").resultAsString());
     }
 }

--- a/tests/src/main/java/com/graphaware/test/integration/ClassPathProcedureUtils.java
+++ b/tests/src/main/java/com/graphaware/test/integration/ClassPathProcedureUtils.java
@@ -28,10 +28,12 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystems;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public final class ClassPathProcedureUtils {
 
@@ -80,7 +82,8 @@ public final class ClassPathProcedureUtils {
                 File file = fileIterator.next();
                 try {
                     String path = file.getAbsolutePath();
-                    Class<?> candidate = Class.forName(path.substring(directory.getAbsolutePath().length() + 1, path.length() - 6).replaceAll("\\/", "."));
+                    Class<?> candidate = Class.forName(path.substring(directory.getAbsolutePath().length() + 1, path.length() - 6)
+                            .replaceAll(Pattern.quote(FileSystems.getDefault().getSeparator()), "."));
 
                     for (Method m : candidate.getDeclaredMethods()) {
                         if (m.isAnnotationPresent(Procedure.class) || m.isAnnotationPresent(UserFunction.class)) {


### PR DESCRIPTION
Using correct file separator based on the file system. Without that fix the framework does not work on the Windows and also the tests are failing.

Fixed newline from hardcoded /n to System.lineSeparator to make the test pass on OS with different line separators.